### PR TITLE
Connect cities via left click

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,4 @@
-use crate::dijkstra::{GlobePoints, GridPoint};
+use crate::dijkstra::GlobePoints;
 use crate::perlin;
 
 use bevy::prelude::*;
@@ -41,6 +41,5 @@ impl Default for Config {
 #[derive(Resource, Default)]
 pub struct State {
     pub globe_points: GlobePoints,
-    pub cities: Vec<GridPoint>,
     pub config: Config,
 }


### PR DESCRIPTION
- When left clicking a city, select it, or when there is already a selected city, connect the two with a path. 
- Color the selected city white. 
- Refactoring: put the meshes into a Meshes resource with named elements, and the materials into a Materials resource, instead of having separate "marker" components. 